### PR TITLE
Possible additions...

### DIFF
--- a/example/nocsrf.php
+++ b/example/nocsrf.php
@@ -102,8 +102,7 @@ class NoCSRF
         $max = strlen( $seed ) - 1;
 
         $string = '';
-        // help mt_rand() with a stronger seed
-								srand( ( double ) microtime( microtime() ) * 100000 );
+
         for ( $i = 0; $i < $length; ++$i )
             $string .= $seed{intval( mt_rand( 0.0, $max ) )};
 

--- a/example/nocsrf.php
+++ b/example/nocsrf.php
@@ -102,6 +102,8 @@ class NoCSRF
         $max = strlen( $seed ) - 1;
 
         $string = '';
+        // help mt_rand() with a stronger seed
+								srand( ( double ) microtime( microtime() ) * 100000 );
         for ( $i = 0; $i < $length; ++$i )
             $string .= $seed{intval( mt_rand( 0.0, $max ) )};
 

--- a/nocsrf.php
+++ b/nocsrf.php
@@ -101,7 +101,7 @@ class NoCSRF
         $seed = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijqlmnopqrtsuvwxyz0123456789';
         $max = strlen( $seed ) - 1;
         // help mt_rand() with a stronger seed
-								srand( ( double ) microtime( microtime() ) * 100000 );
+        srand( ( double ) microtime( microtime() ) * 100000 );
         $string = '';
         for ( $i = 0; $i < $length; ++$i )
             $string .= $seed{intval( mt_rand( 0.0, $max ) )};

--- a/nocsrf.php
+++ b/nocsrf.php
@@ -100,7 +100,8 @@ class NoCSRF
     {
         $seed = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijqlmnopqrtsuvwxyz0123456789';
         $max = strlen( $seed ) - 1;
-
+        // help mt_rand() with a stronger seed
+								srand( ( double ) microtime( microtime() ) * 100000 );
         $string = '';
         for ( $i = 0; $i < $length; ++$i )
             $string .= $seed{intval( mt_rand( 0.0, $max ) )};

--- a/nocsrf.php
+++ b/nocsrf.php
@@ -100,8 +100,7 @@ class NoCSRF
     {
         $seed = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijqlmnopqrtsuvwxyz0123456789';
         $max = strlen( $seed ) - 1;
-        // help mt_rand() with a stronger seed
-        srand( ( double ) microtime( microtime() ) * 100000 );
+
         $string = '';
         for ( $i = 0; $i < $length; ++$i )
             $string .= $seed{intval( mt_rand( 0.0, $max ) )};


### PR DESCRIPTION
I went ahead and forked your NoCSRF project in order contribute additional attack vectors that are (IMHO) crucial to preventing CSRF.

The two additional components of the token are a hashed value of the remote address as well as a hashed value of the browser agent.

Both get validated in the same manner as the time stamping already implemented and I tried to keep the code as similar to yours as possible.

Hope it helps.

*EDIT: You may wish to omit the last three commented 'Added some additional seeding for mt_rand()'. It seems that as of PHP4.2 and up this is no longer needed as mt_rand() does it automatically now. My mistake.
