### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
         "php": ">=5.3.2"
     },
     "autoload": {
-        "files": ["nocsrf.php"]
+        "classmap": [""]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "bkcore/nocsrf",
+    "description": "A simple anti-CSRF token generation/checking class written in PHP5.",
+    "homepage": "http://bkcore.com/blog/code/nocsrf-php-class.html",
+    "license": "MIT",
+    "version": "1.0.0",
+    "type": "library",
+    "require": {
+        "php": ">=5.3.2"
+    },
+    "autoload": {
+        "files": ["nocsrf.php"]
+    }
+}


### PR DESCRIPTION
I've added [Composer](http://getcomposer.org) support so NoCSRF is easier to use in a deployment workflow. You should be able to publish this on [Packagist](https://packagist.org) now.

Though one other thing that really helps with Composer usage is tagged releases.
