### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#NoCSRF, a simple PHP5 token class to prevent CSRF attacks.
+# NoCSRF, a simple PHP5 token class to prevent CSRF attacks.
 
 * [Website](http://bkcore.com/blog/code/nocsrf-php-class.html)
 * Author: Thibaut Despoulain


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
